### PR TITLE
Deleting old attribute "learning" and creating enum "type" (learning/practice)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,7 +55,7 @@ module ApplicationHelper
   def with_classifications(classifiable)
     classifications = [
         (classification_label('success', :certificate, :new) if classifiable.new?),
-        (classification_label('info', :university, :learning) if classifiable.learning),
+        (classification_label('info', :university, :learning) if classifiable.learning?),
         (classification_label('warning', :warning, :beta) if classifiable.beta)]
     classifications.compact.join(' ').html_safe
   end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -24,6 +24,11 @@ class Guide < ActiveRecord::Base
 
   has_one :chapter_guide
 
+  #Deactivate STI, so I can use type attribute
+  self.inheritance_column = nil
+
+  enum type: [ :learning, :practice ]
+
   #TODO denormalize
   def search_tags
     exercises.flat_map(&:search_tags).uniq

--- a/db/migrate/20151229153839_replace_learning_with_type_in_guides.rb
+++ b/db/migrate/20151229153839_replace_learning_with_type_in_guides.rb
@@ -1,0 +1,6 @@
+class ReplaceLearningWithTypeInGuides < ActiveRecord::Migration
+  def change
+    remove_column :guides, :learning, :boolean, default: false
+    add_column :guides, :type, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151224174248) do
+ActiveRecord::Schema.define(version: 20151229153839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -138,10 +138,10 @@ ActiveRecord::Schema.define(version: 20151224174248) do
     t.integer  "language_id"
     t.text     "extra"
     t.text     "corollary"
-    t.boolean  "learning",     default: false
     t.boolean  "beta",         default: false
     t.text     "expectations"
     t.string   "slug",         default: "",    null: false
+    t.integer  "type",         default: 0,     null: false
   end
 
   add_index "guides", ["name"], name: "index_guides_on_name", using: :btree


### PR DESCRIPTION
Fixes #392 
(However this won't fix migration from bibliotheca because there are still some guides stored there that have 'learning', 'original_id_format' and exercises with 'original_id' attributes that should be removed or the guide reimported)