### PR TITLE
Feature improved progress button labels

### DIFF
--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -1,3 +1,3 @@
-module LessonsHelper
+module BooksHelper
   include WithProgressRendering
 end

--- a/app/helpers/concerns/with_progress_rendering.rb
+++ b/app/helpers/concerns/with_progress_rendering.rb
@@ -1,0 +1,18 @@
+module WithProgressRendering
+  def lesson_practice_key_for(stats)
+    if stats.try(:started?)
+      :continue_lesson
+    else
+      :start_lesson
+    end
+  end
+
+  #FIXME refactorme: similar methods
+  def book_practice_key_for(student)
+    if student.try(:last_exercise)
+      :continue_practicing
+    else
+      :start_practicing
+    end
+  end
+end

--- a/app/helpers/concerns/with_stats_rendering.rb
+++ b/app/helpers/concerns/with_stats_rendering.rb
@@ -1,9 +1,0 @@
-module WithStatsRendering
-  def practice_key_for(stats)
-    if stats && stats.started?
-      :continue_practicing
-    else
-      :start_practicing
-    end
-  end
-end

--- a/app/views/book/show.html.erb
+++ b/app/views/book/show.html.erb
@@ -19,7 +19,7 @@
   <% @book.next_lesson_for(current_user).try do |lesson| %>
     <div class="actions">
       <a href="<%= lesson_path(lesson) %>" class="btn btn-success">
-        <%= current_user.try(&:last_exercise).present?? t(:continue_practicing) : t(:start_practicing) %>
+        <%= t book_practice_key_for(current_user) %>
       </a>
     </div>
   <% end %>

--- a/app/views/layouts/_guide.html.erb
+++ b/app/views/layouts/_guide.html.erb
@@ -23,7 +23,7 @@
 
       <div class="actions">
         <% if !@stats.try(:done?) && @next_exercise %>
-          <%= link_to t(practice_key_for(@stats)), exercise_path(@next_exercise), class: 'btn btn-success' %>
+          <%= link_to t(lesson_practice_key_for(@stats)), exercise_path(@next_exercise), class: 'btn btn-success' %>
         <% end %>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,7 +17,8 @@ en:
   console: Console
   contact_administrator: 'If you think this is not supposed to happen, please contact the admin: %{link}'
   content: Content
-  continue_practicing: Continue Practicing!
+  continue_practicing: Continue practicing!
+  continue_lesson: Continue this lesson!
   contributors: Contributors
   corollary: Corollary
   create_submission: Submit
@@ -105,6 +106,7 @@ en:
   something_went_wrong: Something went wrong!
   something_went_wrong_explanation: Something is broken in Mumuki. And we need to solve this as soon as possible, %{issues}.
   start_practicing: Start Practicing!
+  start_lesson: Start this lesson!
   stats: Some stats
   status: Status
   submission: submission

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -20,6 +20,7 @@ es:
   contact_administrator: 'Si pensás que es un error, comunicate con el administrador: %{link}'
   content: Contenido
   continue_practicing: ¡Seguí aprendiendo!
+  continue_lesson: ¡Continuá esta lección!
   contributors: Autores
   corollary: Para pensar
   create_submission: Enviar
@@ -123,6 +124,7 @@ es:
   something_went_wrong: ¡Ups!, algo no anduvo bien....
   something_went_wrong_explanation: Algo se rompió feo en Mumuki. Y necesitamos solucionarlo urgentemente, %{issues}
   start_practicing: ¡Empezá ahora!
+  start_lesson: ¡Comenzá esta lección!
   stats: Tu Progreso
   status: Estado
   submission: solución

--- a/spec/features/guides_flow_spec.rb
+++ b/spec/features/guides_flow_spec.rb
@@ -75,7 +75,7 @@ feature 'Guides Flow' do
     expect(page).to have_text('An awesome guide')
     expect(page).to have_text('Content')
 
-    click_on 'Start Practicing'
+    click_on 'Start this lesson'
 
     expect(page).to have_text('Description of foo')
   end

--- a/spec/features/standard_flow_spec.rb
+++ b/spec/features/standard_flow_spec.rb
@@ -25,7 +25,7 @@ feature 'Standard Flow' do
     expect(page).to have_text('Values are everywhere...')
     expect(page).to have_text('Content')
     expect(page).to have_text('The Basic Values')
-    expect(page).to have_text('Start Practicing!')
+    expect(page).to have_text('Start this lesson!')
     expect(page).to_not have_text("Let's say we")
   end
 


### PR DESCRIPTION
Merge after #648 

This PR solves a long-standing usability issue: when navigating mumuki for the first time, you will have to click on a _start practicing_ button twice. 

With this change, you have plain `start_practicing` buttons and `start_lesson` buttons, that are similar but with different labels